### PR TITLE
update ffxiv-client.nix to use the latest macOS client due to 404

### DIFF
--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
-    hash = "sha256-BZEDYRuBu9GwOmIgznoajQ50uGA/Y/GaX4xy1somzZE=";
+    hash = "sha256-a20525cce87222e6a9bbd9fe1f818a3aca1a70387ab466f95ccd38916b97b69e";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -7,11 +7,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "ffxiv";
-  version = "1.0.5";
+  version = "1.0.7";
 
   # The Windows installer is a 32-bit app, which won’t run on Darwin because WoW64 is not yet
   # supported there with upstream Wine. The Mac client also has Bink-encoded video files that are
   # needed because the WMV-encoded ones in the Windows client don’t work with Wine by default.
+  # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
     hash = "sha256-BZEDYRuBu9GwOmIgznoajQ50uGA/Y/GaX4xy1somzZE=";


### PR DESCRIPTION
SE silently removed 1.0.5.zip from their CDN over the last few weeks/months. 1.0.7 appeared in their appcast/sparkle XML but has no official way of being download, plus if you download the mac version off the SE site right now it fails to launch on macOS 12.3 due to removal of python2.