### PR TITLE
Fix the hash for 1.0.7.zip

### DIFF
--- a/pkgs/ffxiv/default.nix
+++ b/pkgs/ffxiv/default.nix
@@ -25,7 +25,7 @@ let
     patches = old.patches ++ [
       (fetchpatch {
         url = "https://raw.githubusercontent.com/Sporif/dxvk-async/${dxvk.version}/dxvk-async.patch";
-        hash = "sha256-0c256lg1qfccdr0y80i53xzcfdbknjm8rv682mqga5436v27fcla";
+        hash = "sha256-fWGd0a54C2kQ8slvgGu/6PE3RcReW1yF7mPaBPaW1Fw=";
       })
     ];
   });

--- a/pkgs/ffxiv/default.nix
+++ b/pkgs/ffxiv/default.nix
@@ -25,7 +25,7 @@ let
     patches = old.patches ++ [
       (fetchpatch {
         url = "https://raw.githubusercontent.com/Sporif/dxvk-async/${dxvk.version}/dxvk-async.patch";
-        hash = "sha256-fWGd0a54C2kQ8slvgGu/6PE3RcReW1yF7mPaBPaW1Fw=";
+        hash = "sha256-0c256lg1qfccdr0y80i53xzcfdbknjm8rv682mqga5436v27fcla";
       })
     ];
   });
@@ -183,4 +183,3 @@ stdenvNoCC.mkDerivation rec {
     hydraPlatforms = [ ];
   };
 }
-

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
-    hash = "sha256-0c256lg1qfccdr0y80i53xzcfdbknjm8rv682mqga5436v27fcla";
+    sha256 = "a20525cce87222e6a9bbd9fe1f818a3aca1a70387ab466f95ccd38916b97b69e";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
-    hash = "sha256-BZEDYRuBu9GwOmIgznoajQ50uGA/Y/GaX4xy1somzZE=";
+    hash = "sha256-a20525cce87222e6a9bbd9fe1f818a3aca1a70387ab466f95ccd38916b97b69e";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
-    hash = "sha256-a20525cce87222e6a9bbd9fe1f818a3aca1a70387ab466f95ccd38916b97b69e";
+    hash = "sha256-ogUlzOhyIuapu9n+H4GKOsoacDh6tGb5XM04kWuXtp4=";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
-    hash = "sha256-ogUlzOhyIuapu9n+H4GKOsoacDh6tGb5XM04kWuXtp4=";
+    hash = "sha256-0c256lg1qfccdr0y80i53xzcfdbknjm8rv682mqga5436v27fcla";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/ffxiv/ffxiv-client.nix
+++ b/pkgs/ffxiv/ffxiv-client.nix
@@ -7,11 +7,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "ffxiv";
-  version = "1.0.5";
+  version = "1.0.7";
 
   # The Windows installer is a 32-bit app, which won’t run on Darwin because WoW64 is not yet
   # supported there with upstream Wine. The Mac client also has Bink-encoded video files that are
   # needed because the WMV-encoded ones in the Windows client don’t work with Wine by default.
+  # the 1.0.5 version was pulled off Square Enix CDN and replaced with the unreleased 1.0.7 version for macOS.
   src = fetchurl {
     url = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-${version}.zip";
     hash = "sha256-BZEDYRuBu9GwOmIgznoajQ50uGA/Y/GaX4xy1somzZE=";


### PR DESCRIPTION
In my "never used nixos before" noobness I didn't understand what kind of hash it wanted so the version you merged errors with an invalid has. this one is confirmed working.

I don't really know what the difference is with SRI or a regular sha256 hash though.